### PR TITLE
Fixed import issue that prevented use of script with default FIJI installation

### DIFF
--- a/python/imagej/tabulate_filepaths.py
+++ b/python/imagej/tabulate_filepaths.py
@@ -149,7 +149,7 @@ class OpenImageFromTableCell(AbstractAction):
       print rel_path
       if rel_path.endswith(".klb"):
         if(KLB==None):
-      	  print "Cannot open KLB due to missing module"
+          print "Cannot open KLB due to missing module"
         try:
           klb = KLB.newInstance()
           img = klb.readFull(os.path.join(base_path, rel_path))

--- a/python/imagej/tabulate_filepaths.py
+++ b/python/imagej/tabulate_filepaths.py
@@ -158,7 +158,7 @@ class OpenImageFromTableCell(AbstractAction):
           print sys.exc_info()
       else:
         print "via IJ.open"
-      	IJ.open(os.path.join(base_path, rel_path))
+        IJ.open(os.path.join(base_path, rel_path))
     exe.submit(openImage)
     
 

--- a/python/imagej/tabulate_filepaths.py
+++ b/python/imagej/tabulate_filepaths.py
@@ -24,7 +24,13 @@ from functools import partial
 import re
 import os
 import sys
-from org.janelia.simview.klb import KLB
+
+try: # try-except block allows users with default FIJI to run the script without KLB installation
+	from org.janelia.simview.klb import KLB 
+except ImportError:
+	print "Warning: KLB format unavailable"
+	KLB = None
+
 from net.imglib2.img.display.imagej import ImageJFunctions as IL
 
 
@@ -142,6 +148,8 @@ class OpenImageFromTableCell(AbstractAction):
     def openImage():
       print rel_path
       if rel_path.endswith(".klb"):
+      	if(KLB==None):
+      		print "Cannot open KLB due to missing module"
         try:
           klb = KLB.newInstance()
           img = klb.readFull(os.path.join(base_path, rel_path))
@@ -150,7 +158,7 @@ class OpenImageFromTableCell(AbstractAction):
           print sys.exc_info()
       else:
         print "via IJ.open"
-        IJ.open(os.path.join(base_path, rel_path))
+      	IJ.open(os.path.join(base_path, rel_path))
     exe.submit(openImage)
     
 

--- a/python/imagej/tabulate_filepaths.py
+++ b/python/imagej/tabulate_filepaths.py
@@ -148,8 +148,8 @@ class OpenImageFromTableCell(AbstractAction):
     def openImage():
       print rel_path
       if rel_path.endswith(".klb"):
-      	if(KLB==None):
-      		print "Cannot open KLB due to missing module"
+        if(KLB==None):
+      	  print "Cannot open KLB due to missing module"
         try:
           klb = KLB.newInstance()
           img = klb.readFull(os.path.join(base_path, rel_path))

--- a/python/imagej/tabulate_filepaths.py
+++ b/python/imagej/tabulate_filepaths.py
@@ -26,10 +26,10 @@ import os
 import sys
 
 try: # try-except block allows users with default FIJI to run the script without KLB installation
-	from org.janelia.simview.klb import KLB 
+  from org.janelia.simview.klb import KLB 
 except ImportError:
-	print "Warning: KLB format unavailable"
-	KLB = None
+  print "Warning: KLB format unavailable"
+  KLB = None
 
 from net.imglib2.img.display.imagej import ImageJFunctions as IL
 

--- a/python/imagej/tabulate_filepaths.py
+++ b/python/imagej/tabulate_filepaths.py
@@ -41,8 +41,8 @@ txt_file = None  # Set to e.g. "/path/to/list.txt"
 base_path = None
 
 # Laptop via sshfs
-#txt_file = "/home/albert/zstore1/barnesc/LarvalScreen.txt"
-#base_path = "/home/albert/zstore1/barnesc/flylight-backups/LarvalScreen/"
+txt_file = "/Volumes/zfs/barnesc/flylight-backups/LarvalScreen/manifest.txt"
+base_path = "/Volumes/zfs/barnesc/flylight-backups/LarvalScreen/"
 
 # At LMB desktop:
 #txt_file = "/home/albert/LarvalScreen.txt"


### PR DESCRIPTION
`from org.janelia.simview.klb import KLB` is not available in default FIJI and so the script throws an error. Added a try/catch block to prevent this issue for users who aren't interested in installing a KLB module